### PR TITLE
Added possibility to configure the extension of the output files

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -14,4 +14,7 @@ return [
     'output_transform' => [
         'App\\Enums\\' => '',
     ],
+
+    // Set a specific extension for the output files (without a dot character).
+    'output_file_extension' => 'js',
 ];

--- a/src/Console/Commands/GenerateCommand.php
+++ b/src/Console/Commands/GenerateCommand.php
@@ -73,7 +73,7 @@ class GenerateCommand extends Command
         foreach (config('laravel-enum-js.output_transform') as $pattern => $replacement) {
             $outputPath = preg_replace('/' . preg_quote($pattern) . '/', $replacement, $outputPath);
         }
-        $outputPath .= '.js';
+        $outputPath .= '.' . config('laravel-enum-js.output_file_extension');
 
         $reflection = new \ReflectionClass($class);
 


### PR DESCRIPTION
# Problem

My project uses strictly typescript. Hence, possibility to output `.ts` files instead of `.js` files would be nice.

# Solution

Solution is very simple - add config variable and set file endings in respect to that variable. Typescript files have the same syntax as javascript files in the case of this repository's functionality, so no code changes required regarding the outputted syntax.