### PR TITLE
Add support for constants inside an enum

### DIFF
--- a/src/Console/Commands/GenerateCommand.php
+++ b/src/Console/Commands/GenerateCommand.php
@@ -77,15 +77,14 @@ class GenerateCommand extends Command
 
         $reflection = new \ReflectionClass($class);
 
-        $is_enum = method_exists($reflection, 'isEnum') && $reflection->isEnum();
-
         $outputString = '';
-        foreach ($reflection->getConstants() as $key => $value) {
-            if ($is_enum) {
+        foreach ($reflection->getReflectionConstants() as $constant) {
+            $value = $constant->getValue();
+            if (method_exists($constant, 'isEnumCase') && $constant->isEnumCase()) {
                 $value = property_exists($value, 'value') ? $value->value : $value->name;
             }
 
-            $outputString .= sprintf("export const %s = %s\n", $key, json_encode($value));
+            $outputString .= sprintf("export const %s = %s\n", $constant->getName(), json_encode($value));
         }
 
         Storage::disk(config('laravel-enum-js.output_disk'))->put($outputPath, $outputString);

--- a/tests/Console/Commands/GenerateCommandTest.php
+++ b/tests/Console/Commands/GenerateCommandTest.php
@@ -61,15 +61,15 @@ class GenerateCommandTest extends TestCase
             ],
             'native' => [
                 'filename' => 'Native/Base.php',
-                'expectedContent' => "export const Value1 = \"Value1\"\nexport const Value2 = \"Value2\"\n",
+                'expectedContent' => "export const Value1 = \"Value1\"\nexport const Value2 = \"Value2\"\nexport const ADDITIONAL_CONST = [\"example\"]\n",
             ],
             'native backed int' => [
                 'filename' => 'Native/BackedInt.php',
-                'expectedContent' => "export const Value1 = 1\nexport const Value2 = 2\n",
+                'expectedContent' => "export const Value1 = 1\nexport const Value2 = 2\nexport const ADDITIONAL_CONST = [\"example\"]\n",
             ],
             'native backed string' => [
                 'filename' => 'Native/BackedString.php',
-                'expectedContent' => "export const Value1 = \"value-1\"\nexport const Value2 = \"value-2\"\n",
+                'expectedContent' => "export const Value1 = \"value-1\"\nexport const Value2 = \"value-2\"\nexport const ADDITIONAL_CONST = [\"example\"]\n",
             ],
             'array' => [
                 'filename' => 'ArrayValue.php',

--- a/tests/resources/Enums/Native/BackedInt.php
+++ b/tests/resources/Enums/Native/BackedInt.php
@@ -6,4 +6,8 @@ enum BackedInt : int
 {
     case Value1 = 1;
     case Value2 = 2;
+
+    const ADDITIONAL_CONST = [
+        'example',
+    ];
 }

--- a/tests/resources/Enums/Native/BackedString.php
+++ b/tests/resources/Enums/Native/BackedString.php
@@ -6,4 +6,8 @@ enum BackedString : string
 {
     case Value1 = 'value-1';
     case Value2 = 'value-2';
+
+    const ADDITIONAL_CONST = [
+        'example',
+    ];
 }

--- a/tests/resources/Enums/Native/Base.php
+++ b/tests/resources/Enums/Native/Base.php
@@ -6,4 +6,8 @@ enum Base
 {
     case Value1;
     case Value2;
+
+    const ADDITIONAL_CONST = [
+        'example',
+    ];
 }


### PR DESCRIPTION
PHP allows for constants to be defined inside an enum.

This change checks whether a constant is an enum case and changes the output behaviour accordingly.