### PR TITLE
Enums as object style configuration

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -17,4 +17,7 @@ return [
 
     // Set a specific extension for the output files (without a dot character).
     'output_file_extension' => 'js',
+
+    // Set true to export the enums as a single object, false to export them as individual constants
+    'as_object' => false,
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -18,6 +18,7 @@ return [
     // Set a specific extension for the output files (without a dot character).
     'output_file_extension' => 'js',
 
-    // Set true to export the enums as a single object, false to export them as individual constants
-    'as_object' => false,
+    // here you may configure the desired output style for the generated js files.
+    // Available options: 'constant', 'object'
+    'output_style' => 'constant',
 ];

--- a/src/Console/Commands/GenerateCommand.php
+++ b/src/Console/Commands/GenerateCommand.php
@@ -4,6 +4,7 @@ namespace Modstore\LaravelEnumJs\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;
+use const PATHINFO_FILENAME;
 
 class GenerateCommand extends Command
 {
@@ -43,8 +44,8 @@ class GenerateCommand extends Command
         Storage::disk(config('laravel-enum-js.output_disk'))->delete($files);
 
         $pattern = '/' . collect(config('laravel-enum-js.namespaces'))->map(function ($item) {
-            return str_replace('\\*', '.+', preg_quote($item));
-        })->implode('|') . '/';
+                return str_replace('\\*', '.+', preg_quote($item));
+            })->implode('|') . '/';
 
         $classLoader = require('vendor/autoload.php');
         $classes = array_unique(array_merge(get_declared_classes(), array_keys($classLoader->getClassMap())));
@@ -67,7 +68,7 @@ class GenerateCommand extends Command
      * @param string $class
      * @throws \ReflectionException
      */
-    protected function writeFile(string $class)
+    protected function writeFile(string $class): void
     {
         $outputPath = $class;
         foreach (config('laravel-enum-js.output_transform') as $pattern => $replacement) {
@@ -77,18 +78,58 @@ class GenerateCommand extends Command
 
         $reflection = new \ReflectionClass($class);
 
-        $outputString = '';
-        foreach ($reflection->getReflectionConstants() as $constant) {
-            $value = $constant->getValue();
-            if (method_exists($constant, 'isEnumCase') && $constant->isEnumCase()) {
-                $value = property_exists($value, 'value') ? $value->value : $value->name;
-            }
+        if(config('laravel-enum-js.as_object', false)) {
+            $exploded=explode('\\', $class);
+            $objectName = end($exploded);
+            $outputString = $this->writeAsObject($reflection->getReflectionConstants(), $objectName);
+        } else {
+            $outputString = $this->writeAsConst($reflection->getReflectionConstants());
+        }
 
-            $outputString .= sprintf("export const %s = %s\n", $constant->getName(), json_encode($value));
+        if(!$outputString) {
+            $this->error(sprintf('Failed to write file for class: %s', $class));
+            return;
         }
 
         Storage::disk(config('laravel-enum-js.output_disk'))->put($outputPath, $outputString);
 
         $this->info(sprintf('File written to: %s', $outputPath));
+    }
+
+    private function getEnumValue($enumCase): mixed
+    {
+        $value = $enumCase->getValue();
+        if (method_exists($enumCase, 'isEnumCase') && $enumCase->isEnumCase()) {
+            $value = property_exists($value, 'value') ? $value->value : $value->name;
+        }
+
+        return $value;
+    }
+
+    private function writeAsConst(array $cases): string
+    {
+        $outputString = '';
+        foreach ($cases as $case) {
+            $value = $this->getEnumValue($case);
+
+            $outputString .= sprintf("export const %s = %s\n", $case->getName(), json_encode($value));
+        }
+
+        return $outputString;
+    }
+
+    private function writeAsObject(array $cases, string $objectName): string
+    {
+        $outputString = sprintf("export const %s = Object.freeze({\n", $objectName);
+
+        foreach ($cases as $case) {
+            $value = $this->getEnumValue($case);
+
+            $outputString .= sprintf("  %s: %s,\n", $case->getName(), json_encode($value));
+        }
+
+        $outputString .= '})';
+
+        return $outputString;
     }
 }

--- a/src/Console/Commands/GenerateCommand.php
+++ b/src/Console/Commands/GenerateCommand.php
@@ -79,8 +79,7 @@ class GenerateCommand extends Command
 
         $reflection = new \ReflectionClass($class);
 
-        $formatAsObject = config('laravel-enum-js.as_object', false);
-        $formatter = OutputFormatFactory::create($formatAsObject ? 'object' : 'constant', $reflection);
+        $formatter = OutputFormatFactory::create( config('laravel-enum-js.output_style', 'constant'), $reflection);
 
         Storage::disk(config('laravel-enum-js.output_disk'))->put($outputPath, $formatter->getFileContents());
 

--- a/src/Resources/ConstantFormatter.php
+++ b/src/Resources/ConstantFormatter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Modstore\LaravelEnumJs\Resources;
+
+use ReflectionClass;
+
+class ConstantFormatter extends OutputFormatter
+{
+    public function __construct(ReflectionClass $class)
+    {
+        parent::__construct($class);
+    }
+
+    protected function printCase($case): string
+    {
+        $value = $this->getEnumValue($case);
+
+        return sprintf("export const %s = %s\n", $case->getName(), json_encode($value));
+    }
+}

--- a/src/Resources/ObjectFormatter.php
+++ b/src/Resources/ObjectFormatter.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Modstore\LaravelEnumJs\Resources;
+
+use ReflectionClass;
+
+class ObjectFormatter extends OutputFormatter
+{
+    public function __construct(ReflectionClass $class)
+    {
+        parent::__construct($class);
+    }
+
+    protected function printCase($case): string
+    {
+        $value = $this->getEnumValue($case);
+
+        return sprintf("  %s: %s,\n", $case->getName(), json_encode($value));
+    }
+
+    protected function getStart(): string
+    {
+        $exploded=explode('\\', $this->class->getName());
+        $objectName = end($exploded);
+
+        return sprintf("export const %s = Object.freeze({\n", $objectName);
+    }
+
+    protected function getEnd(): string
+    {
+        return '})';
+    }
+}

--- a/src/Resources/OutputFormatFactory.php
+++ b/src/Resources/OutputFormatFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Modstore\LaravelEnumJs\Resources;
+
+use ReflectionClass;
+
+class OutputFormatFactory
+{
+
+    /**
+     * @param string $type
+     * @param ReflectionClass $class
+     * @return OutputFormatter
+     */
+    public static function create(string $type, ReflectionClass $class): OutputFormatter
+    {
+        return match ($type) {
+            'object' => new ObjectFormatter($class),
+            'constant' => new ConstantFormatter($class),
+            default => throw new \InvalidArgumentException("Invalid output format type: {$type}"),
+        };
+    }
+
+}

--- a/src/Resources/OutputFormatter.php
+++ b/src/Resources/OutputFormatter.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Modstore\LaravelEnumJs\Resources;
+
+use ReflectionClass;
+
+abstract class OutputFormatter
+{
+    public function __construct(protected readonly ReflectionClass $class)
+    {
+    }
+
+    /**
+     * Define how each of the enum cases should be printed.
+     *
+     * @param $case
+     * @return string
+     */
+    protected abstract function printCase($case): string;
+
+    /**
+     * Define how the start of the file should be printed.
+     *
+     * @return string
+     */
+    protected function getStart(): string
+    {
+        return '';
+    }
+
+    /**
+     * Define how the end of the file should be printed.
+     *
+     * @return string
+     */
+    protected function getEnd(): string
+    {
+        return '';
+    }
+
+    public function getFileContents(): string
+    {
+        $output = $this->getStart();
+
+        foreach ($this->class->getReflectionConstants() as $case) {
+            $output .= $this->printCase($case);
+        }
+
+        $output .= $this->getEnd();
+
+        return $output;
+    }
+
+    protected function getEnumValue($enumCase): mixed
+    {
+        $value = $enumCase->getValue();
+        if (method_exists($enumCase, 'isEnumCase') && $enumCase->isEnumCase()) {
+            $value = property_exists($value, 'value') ? $value->value : $value->name;
+        }
+
+        return $value;
+    }
+}

--- a/tests/Console/Commands/GenerateCommandTest.php
+++ b/tests/Console/Commands/GenerateCommandTest.php
@@ -130,7 +130,7 @@ class GenerateCommandTest extends TestCase
      */
     public function testGeneratedObjectFormat(string $filename, string $expectedContent)
     {
-        Config::set('laravel-enum-js.as_object', true);
+        Config::set('laravel-enum-js.output_style', 'object');
 
         include_once('tests/resources/Enums/' . $filename);
 


### PR DESCRIPTION
## Description

This PR introduces a new configuration option that allows users to export enums as a single object per file, with enum cases represented as properties.

By setting the new config value 'output_style' => 'object', the generated JS file will follow this format:

```
export const StatusEnum = Object.freeze({
  ACTIVE: "active",
  INACTIVE: "inactive",
})
```

The name of the exported object will also be used as the filename.

The default export style ("as constants") remains unchanged, so no breaking changes are introduced.

The implementation is designed in a way that makes it easy to extend in the future—for example, to support additional output styles or customization options.

Feedback and suggestions are welcome!